### PR TITLE
Command Line Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ Google Drive Download Script
 -   Works with large files
 -   Files / Folders must have been shared via link
 
-### Usage
+## Usage
 
 ```bash
-python gdrivedl.py <URL> <DIRECTORY>
+python gdrivedl.py <URL>
 ```
 -   URL is Shared Goolge Drive URL containing ID
--   DIRECTORY (Optional, defaults to current directory `./`)
+
+### Options
+Options derive from `wget` conventions where possible.
+
+- `-P` `--directory-prefix` <DIRECTORY>` Download to a different directory
+  (default to the current directory)
+- `-O` `--output-document` Download to a particular filename (defaults to the
+  server filename). Not valid for folder downloads.
+- `-q` `--quiet` Don't print progress bar
+- `-v` `--verbose` Additional messages
 
 ### Example Linux Usage
 
@@ -24,5 +33,6 @@ sudo curl https://raw.githubusercontent.com/matthuisman/gdrivedl/master/gdrivedl
 
 sudo chmod +x GDriveDL
 
-./GDriveDL https://drive.google.com/open?id=1yXsJq7TTMgUVXbOnCalyupESFN-tm2nc ./some_folder
+./GDriveDL https://drive.google.com/open?id=1yXsJq7TTMgUVXbOnCalyupESFN-tm2nc -P ./some_folder
 ```
+

--- a/gdrivedl.py
+++ b/gdrivedl.py
@@ -81,7 +81,7 @@ def sanitize(filename):
     return filename
 
 
-def process_item(id, directory):
+def process_item(id, directory, progress=True):
     url = ITEM_URL.format(id=id)
     resp = urlopen(url)
     url = resp.geturl()
@@ -97,9 +97,9 @@ def process_item(id, directory):
         file_size = int(data[25][2])
         file_path = os.path.join(directory, file_name)
 
-        process_file(id, file_path, file_size)
+        process_file(id, file_path, file_size, progress=progress)
     elif '/folders/' in url:
-        process_folder(id, directory, html=html)
+        process_folder(id, directory, html=html, progress=progress)
     elif 'ServiceLogin' in url:
         logging.error('Id {} does not have link sharing enabled'.format(id))
         sys.exit(1)
@@ -108,7 +108,7 @@ def process_item(id, directory):
         sys.exit(1)
 
 
-def process_folder(id, directory, html=None):
+def process_folder(id, directory, html=None, progress=True):
     if not html:
         url = FOLDER_URL.format(id=id)
         html = urlopen(url).read().decode('utf-8')
@@ -120,9 +120,9 @@ def process_folder(id, directory, html=None):
 
     if not os.path.exists(directory):
         os.mkdir(directory)
-        output('Directory: {directory} [Created]\n'.format(directory=directory))
+        logging.info('Directory: {directory} [Created]'.format(directory=directory))
     else:
-        output('Directory: {directory} [Exists]\n'.format(directory=directory))
+        logging.info('Directory: {directory} [Exists]'.format(directory=directory))
 
     if not data[0]:
         return
@@ -135,14 +135,14 @@ def process_folder(id, directory, html=None):
         item_path = os.path.join(directory, item_name)
 
         if item_type == FOLDER_TYPE:
-            process_folder(item_id, item_path)
+            process_folder(item_id, item_path, progress=progress)
         else:
-            process_file(item_id, item_path, int(item_size))
+            process_file(item_id, item_path, int(item_size), progress=progress)
 
 
-def process_file(id, file_path, file_size, confirm='', cookies=''):
+def process_file(id, file_path, file_size, confirm='', cookies='', progress=True):
     if os.path.exists(file_path):
-        output('{file_path} [Exists]\n'.format(file_path=file_path))
+        logging.info('{file_path} [Exists]\n'.format(file_path=file_path))
         return
 
     url = FILE_URL.format(id=id, confirm=confirm)
@@ -153,7 +153,7 @@ def process_file(id, file_path, file_size, confirm='', cookies=''):
 
     if not confirm and 'download_warning' in cookies:
         confirm = CONFIRM_PATTERN.search(cookies)
-        return process_file(id, file_path, file_size, confirm.group(1), cookies)
+        return process_file(id, file_path, file_size, confirm.group(1), cookies, progress=progress)
 
     output(file_path + '\n')
 
@@ -170,32 +170,38 @@ def process_file(id, file_path, file_size, confirm='', cookies=''):
 
                 dl += len(chunk)
                 f.write(chunk)
-                done = int(50 * dl / file_size)
-                output("\r[{}{}] {:.2f}MB/{:.2f}MB".format(
-                    '=' * done,
-                    ' ' *
-                    (50 - done),
-                    dl / 1024 / 1024,
-                    file_size / 1024 / 1024
-                ))
-                sys.stdout.flush()
+                if progress:
+                    done = int(50 * dl / file_size)
+                    output("\r[{}{}] {:.2f}MB/{:.2f}MB".format(
+                        '=' * done,
+                        ' ' *
+                        (50 - done),
+                        dl / 1024 / 1024,
+                        file_size / 1024 / 1024
+                    ))
+                    sys.stdout.flush()
     except:
         if os.path.exists(file_path):
             os.remove(file_path)
         raise
 
-    output('\n')
+    if progress:
+        output('\n')
 
 
 def main(args=None):
     parser = argparse.ArgumentParser(description='Download google drive files')
     parser.add_argument("url", help="Download URL or ID")
     parser.add_argument("directory", default='./', nargs='?', help="output directory")
-    parser.add_argument("-v", "--verbose", help="Long messages",
-        dest="verbose", default=False, action="store_true")
+    parser.add_argument("-q", "--quiet", help="Disable progress bar",
+        default=False, action="store_true")
     args = parser.parse_args(args)
 
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG if args.verbose else logging.WARN)
+    if args.quiet:
+        logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARN)
+    else:
+        logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+    progress = not args.quiet
 
     url = args.url
     directory = args.directory
@@ -211,7 +217,7 @@ def main(args=None):
         logging.error('Unable to get ID from {}'.format(url))
         sys.exit(1)
 
-    process_item(id, directory)
+    process_item(id, directory, progress=progress)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I needed an option to set the name of the downloaded file. To implement this I switched the command line to use argparse and added some other common arguments.

I have taken option names from `wget`, which has a similar overall purpose. To be consistent this breaks backwards compatibility because wget sets the directory using an option rather than a positional parameter.

```
python gdrivedl.py -h
usage: gdrivedl.py [-h] [-P DIRECTORY_PREFIX] [-O OUTPUT_DOCUMENT] [-q] url

Download google drive files

positional arguments:
  url                   Download URL or ID

optional arguments:
  -h, --help            show this help message and exit
  -P DIRECTORY_PREFIX, --directory-prefix DIRECTORY_PREFIX
                        Output directory
  -O OUTPUT_DOCUMENT, --output-document OUTPUT_DOCUMENT
                        Output filename. Defaults to the server filename. Not
                        valid for folders
  -q, --quiet           Disable progress bar
```